### PR TITLE
Part 2 broken links, WEBDA migrated

### DIFF
--- a/Python_tutorial_sequence/Part2/Isochrone_EXERCISES.ipynb
+++ b/Python_tutorial_sequence/Part2/Isochrone_EXERCISES.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"http://www.nasa.gov/sites/default/files/thumbnails/image/potw1452a.jpg\" width=600>\n",
+    "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/Potw1452a.tif/lossy-page1-911px-Potw1452a.tif.jpg\" width=600>\n",
     "(NGC 6535)"
    ]
   },
@@ -40,7 +40,7 @@
     "\n",
     "First we'll investigate the spatial distribution of these star clusters using the data sets : <a href=\"data/GlobularClusters_clean.tab\">GlobularClusters_clean.tab</a> and <a href=\"data/OpenClusters_clean.tab\">OpenClusters_clean.tab</a>, in your data folder. \n",
     "\n",
-    "(The GC table is a cleaned up version of the <a href=\"http://spider.seds.org/spider/MWGC/mwgc.html\">original data table from SEDs</a>, and the OC table is a cleaned up version of <a href=\"https://www.univie.ac.at/webda/tadross.html\">this one</a>.)\n",
+    "(The GC table is a cleaned up version of the <a href=\"http://spider.seds.org/spider/MWGC/mwgc.html\">original data table from SEDs</a>, and the OC table is a cleaned up version of <a href=\"https://webda.physics.muni.cz/tadross.html\">this one</a>.)\n",
     "\n",
     "Both tables contain the [RA](https://en.wikipedia.org/wiki/Right_ascension) and [Dec](https://en.wikipedia.org/wiki/Declination) location, distance from our Sun and from the galactic center in kilolightyears (kly), [apparent magnitude](https://en.wikipedia.org/wiki/Apparent_magnitude) in the V-band, and [angular size](https://en.wikipedia.org/wiki/Angular_diameter) of the cluster."
    ]
@@ -187,7 +187,7 @@
     "plt.grid(True)\n",
     "\n",
     "#GCs\n",
-    "ax.scatter(GC_Coords.ra.wrap_at(180.*u.degree).radian,GC_Coords.dec.radian,c=---, s=---, cmap='cool')\n",
+    "ax.scatter(GC_Coords.ra.wrap_at(180.*u.degree).radian,\"https://www.univie.ac.at/webda/tadross.html\"GC_Coords.dec.radian,c=---, s=---, cmap='cool')\n",
     "\n",
     "#OCs, plot using the \"autumn\" color map\n",
     "ax.scatter(--)\n",
@@ -604,9 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot the best-fit isochorone over the observed data \n",
@@ -681,9 +679,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Go to http://www.univie.ac.at/webda/navigation.html\n",
+    "Go to https://webda.physics.muni.cz/navigation.html\n",
     "\n",
-    "This site allows you to download data from pretty much any open star cluster in our galaxy that might be of interest to you. For the full list of clusters included in this site, click <a href=\"http://www.univie.ac.at/webda/complete_ad.html\">here</a>. Pick one that interests you. For additional information about each cluster, look it up in <a href=\"http://ned.ipac.caltech.edu/forms/byname.html\">NED (the NASA Extragalactic Database)</a>.\n",
+    "This site allows you to download data from pretty much any open star cluster in our galaxy that might be of interest to you. For the full list of clusters included in this site, click <a href=\"https://webda.physics.muni.cz/complete_ad.html\">here</a>. Pick one that interests you. For additional information about each cluster, look it up in <a href=\"http://ned.ipac.caltech.edu/forms/byname.html\">NED (the NASA Extragalactic Database)</a>.\n",
     "\n",
     "- Type the name for any star cluster of your choice (for example, M67) in the box labelled 'Display the Page of the Cluster'. Hit enter.\n",
     "- Make a note of the value for this cluster's ‘Reddening’ and the ‘Distance Modulus’, listed under ‘Basic Parameters’.\n",
@@ -695,7 +693,7 @@
     "- Copy your star cluster data into this text file. These (and the isochrone data below) are the data you'll use to determine the age of your star cluster.\n",
     "- Explore the site. What other data can you download about each cluster (i.e., positions, other filter magnitudes, etc.)?\n",
     "\n",
-    "<a href=\"http://www.univie.ac.at/webda/description.html#base_level\">General information about the history and use of WEBDA</a>."
+    "<a href=\"https://webda.physics.muni.cz/description.html#base_level\">General information about the history and use of WEBDA</a>."
    ]
   },
   {
@@ -708,7 +706,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "\n",
@@ -717,8 +718,8 @@
     "- Use the default values under “Evolutionary Tracks”.\n",
     "- Make sure the photometric system is appropriate for your data (i.e., if you’re using UBV data, then choose the one that starts with UBV).\n",
     "- Keep the default values for “Dust”,”Extinction”, “Initial Mass Function”\n",
-    "- Under Ages, select: Sequence of isochrones of constant metallicity...\n",
-    "    - Change Z=0.008 to Z=0.019 (this is the value for solar metallicity)\n",
+    "- Under Ages, select a sequence of isochrones of constant metallicity...\n",
+    "    - Change initial and final metallicity to Z=0.019 (this is the value for solar metallicity)\n",
     "    - Change the age range to log(t/yr) = 8.0 to 10.0  (i.e., ages ranging from 100 million years to 10 billion years)\n",
     "- Keep the default selection for 'Output' on Isochrone Tables\n",
     "- Click submit and download the linked file named ‘outputxxx.dat’\n",
@@ -752,9 +753,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/Python_tutorial_sequence/Part2/Isochrone_SOLUTIONS.ipynb
+++ b/Python_tutorial_sequence/Part2/Isochrone_SOLUTIONS.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"http://www.nasa.gov/sites/default/files/thumbnails/image/potw1452a.jpg\" width=600>\n",
+    "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/Potw1452a.tif/lossy-page1-911px-Potw1452a.tif.jpg\" width=600>\n",
     "(NGC 6535)"
    ]
   },
@@ -40,7 +40,7 @@
     "\n",
     "First we'll investigate the spatial distribution of these star clusters using the data sets : <a href=\"data/GlobularClusters_clean.tab\">GlobularClusters_clean.tab</a> and <a href=\"data/OpenClusters_clean.tab\">OpenClusters_clean.tab</a>, in your data folder. \n",
     "\n",
-    "(The GC table is a cleaned up version of the <a href=\"http://spider.seds.org/spider/MWGC/mwgc.html\">original data table from SEDs</a>, and the OC table is a cleaned up version of <a href=\"https://www.univie.ac.at/webda/tadross.html\">this one</a>.)\n",
+    "(The GC table is a cleaned up version of the <a href=\"http://spider.seds.org/spider/MWGC/mwgc.html\">original data table from SEDs</a>, and the OC table is a cleaned up version of <a href=\"https://webda.physics.muni.cz/tadross.html\">this one</a>.)\n",
     "\n",
     "Both tables contain the [RA](https://en.wikipedia.org/wiki/Right_ascension) and [Dec](https://en.wikipedia.org/wiki/Declination) location, distance from our Sun and from the galactic center in kilolightyears (kly), [apparent magnitude](https://en.wikipedia.org/wiki/Apparent_magnitude) in the V-band, and [angular size](https://en.wikipedia.org/wiki/Angular_diameter) of the cluster."
    ]
@@ -353,9 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Here we read in the M67 Isochrones Data Table from data/m67_isochrones.dat, using ascii\n",
@@ -643,9 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot the best-fit isochorone over the observed data\n",
@@ -735,9 +731,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Go to http://www.univie.ac.at/webda/navigation.html\n",
+    "Go to https://webda.physics.muni.cz/navigation.html\n",
     "\n",
-    "This site allows you to download data from pretty much any open star cluster in our galaxy that might be of interest to you. For the full list of clusters included in this site, click <a href=\"http://www.univie.ac.at/webda/complete_ad.html\">here</a>. Pick one that interests you. For additional information about each cluster, look it up in <a href=\"http://ned.ipac.caltech.edu/forms/byname.html\">NED (the NASA Extragalactic Database)</a>.\n",
+    "This site allows you to download data from pretty much any open star cluster in our galaxy that might be of interest to you. For the full list of clusters included in this site, click <a href=\"https://webda.physics.muni.cz/complete_ad.html\">here</a>. Pick one that interests you. For additional information about each cluster, look it up in <a href=\"http://ned.ipac.caltech.edu/forms/byname.html\">NED (the NASA Extragalactic Database)</a>.\n",
     "\n",
     "- Type the name for any star cluster of your choice (for example, M67) in the box labelled 'Display the Page of the Cluster'. Hit enter.\n",
     "- Make a note of the value for this cluster's ‘Reddening’ and the ‘Distance Modulus’, listed under ‘Basic Parameters’.\n",
@@ -749,7 +745,7 @@
     "- Copy your star cluster data into this text file. These (and the isochrone data below) are the data you'll use to determine the age of your star cluster.\n",
     "- Explore the site. What other data can you download about each cluster (i.e., positions, other filter magnitudes, etc.)?\n",
     "\n",
-    "<a href=\"http://www.univie.ac.at/webda/description.html#base_level\">General information about the history and use of WEBDA</a>."
+    "<a href=\"https://webda.physics.muni.cz/description.html#base_level\">General information about the history and use of WEBDA</a>."
    ]
   },
   {
@@ -762,7 +758,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "\n",
@@ -771,8 +770,8 @@
     "- Use the default values under “Evolutionary Tracks”.\n",
     "- Make sure the photometric system is appropriate for your data (i.e., if you’re using UBV data, then choose the one that starts with UBV).\n",
     "- Keep the default values for “Dust”,”Extinction”, “Initial Mass Function”\n",
-    "- Under Ages, select: Sequence of isochrones of constant metallicity...\n",
-    "    - Change Z=0.008 to Z=0.019 (this is the value for solar metallicity)\n",
+    "- Under Ages, select a sequence of isochrones of constant metallicity...\n",
+    "    - Change initial and final metallicity to Z=0.019 (this is the value for solar metallicity)\n",
     "    - Change the age range to log(t/yr) = 8.0 to 10.0  (i.e., ages ranging from 100 million years to 10 billion years)\n",
     "- Keep the default selection for 'Output' on Isochrone Tables\n",
     "- Click submit and download the linked file named ‘outputxxx.dat’\n",
@@ -810,5 +809,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
-Fixed broken image link
-WEBDA has moved to https://webda.physics.muni.cz/. Fixed all related links and checked that the instructions for accessing the data still apply.
-Slight change in wording to instructions for grabbing isochrone data from http://stev.oapd.inaf.it/cgi-bin/cmd