### PR TITLE
Fixed broken tutorial link. Rewording/typos

### DIFF
--- a/Python_tutorial_sequence/Part4/Gaia_M67_EXERCISES.ipynb
+++ b/Python_tutorial_sequence/Part4/Gaia_M67_EXERCISES.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<i>[Gaia](http://sci.esa.int/gaia/) is an [ESA](http://www.esa.int/ESA) satellite aiming to chart a three-dimensional map of our Galaxy, the Milky Way.  On 13 June 2022, Gaia had it's third data release, [DR3](https://www.cosmos.esa.int/web/gaia/dr3), that contains positions and velocities for over a billion stars.  We will use a subset of these data here, for a specific [open star cluster](https://en.wikipedia.org/wiki/Open_cluster) [M67](https://en.wikipedia.org/wiki/Messier_67)\n",
     "\n",
-    "This workshop builds off of the tutorial here: http://gea.esac.esa.int/archive-help/tutorials/python_cluster/index.html\n",
+    "This workshop builds off of the tutorial here: https://www.cosmos.esa.int/web/gaia-users/archive/use-cases#datalink_dr3_pleiades\n",
     "\n",
     "\n",
     "Author: Aaron Geller <br/> June 2018, updated June 2022</i>\n"
@@ -222,7 +222,7 @@
     "P\\left(v\\right) = \\frac{F_\\mathrm{cluster}\\left(v\\right)}{F_\\mathrm{cluster}\\left(v\\right) + F_\\mathrm{field}\\left(v\\right)}\n",
     "$$\n",
     "\n",
-    "*Use this formula below.  Then plot a histogram of the $P\\left(v\\right)$ distribution. Stars with $P\\left(v\\right) \\sim 1$ are high-probability members, while those with $P\\left(v\\right) \\sim 0$ are non-members.  You will want to pick some cutoff to select the members. Then use $\\texttt{numpy.where}$ to get the indices of these radial-velocity members.  You may also want to plot a CMD to look at them.*"
+    "*Here, $F_\\mathrm{cluster}\\left(v\\right)$ and $F_\\mathrm{field}\\left(v\\right)$ are the cluster (narrow) and field (broad) components of our two-component Gaussian model. Use this formula below.  Then plot a histogram of the $P\\left(v\\right)$ distribution. Stars with $P\\left(v\\right) \\sim 1$ are high-probability members, while those with $P\\left(v\\right) \\sim 0$ are non-members.  You will want to pick some cutoff to select the members. Then use $\\texttt{numpy.where}$ to get the indices of these radial-velocity members.  You may also want to plot a CMD to look at them.*"
    ]
   },
   {
@@ -252,9 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dist = (r['parallax']).to(u.parsec, equivalencies=u.parallax())\n",
@@ -268,7 +266,7 @@
    "source": [
     "*Now we want to fit the data again, so that we can derive cluster memberships based on distance.  Formally, there is no reason to think the cluster should be a Guassian distribution. (It should be fit with a \"[King model](http://adsabs.harvard.edu/abs/1962AJ.....67..471K)\".)  But let's approximate this by a 1D Gaussian.  Then we can fit the rest of the field with a simple polynomial.*\n",
     "\n",
-    "*Perform this fit to the distance, using $\\texttt{astropy}$.  I suggest using a polynomail of degree 6. Plot the fit on top of the histogram of distances.*"
+    "*Perform this fit to the distance, using $\\texttt{astropy}$.  I suggest using a polynomial of degree 6 for the field. Plot the fit on top of the histogram of distances.*"
    ]
   },
   {
@@ -530,9 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#the Hyades\n"
@@ -573,9 +569,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/Python_tutorial_sequence/Part4/Gaia_M67_SOLUTIONS.ipynb
+++ b/Python_tutorial_sequence/Part4/Gaia_M67_SOLUTIONS.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<i>[Gaia](http://sci.esa.int/gaia/) is an [ESA](http://www.esa.int/ESA) satellite aiming to chart a three-dimensional map of our Galaxy, the Milky Way.  On 13 June 2022, Gaia had it's third data release, [DR3](https://www.cosmos.esa.int/web/gaia/dr3), that contains positions and velocities for over a billion stars.  We will use a subset of these data here, for a specific [open star cluster](https://en.wikipedia.org/wiki/Open_cluster) [M67](https://en.wikipedia.org/wiki/Messier_67)\n",
     "\n",
-    "This workshop builds off of the tutorial here: http://gea.esac.esa.int/archive-help/tutorials/python_cluster/index.html\n",
+    "This workshop builds off of the tutorial here: https://www.cosmos.esa.int/web/gaia-users/archive/use-cases#datalink_dr3_pleiades\n",
     "\n",
     "\n",
     "Author: Aaron Geller <br/> June 2018, updated June 2022</i>\n"
@@ -236,7 +236,7 @@
     "P\\left(v\\right) = \\frac{F_\\mathrm{cluster}\\left(v\\right)}{F_\\mathrm{cluster}\\left(v\\right) + F_\\mathrm{field}\\left(v\\right)}\n",
     "$$\n",
     "\n",
-    "*Use this formula below.  Then plot a histogram of the $P\\left(v\\right)$ distribution. Stars with $P\\left(v\\right) \\sim 1$ are high-probability members, while those with $P\\left(v\\right) \\sim 0$ are non-members.  You will want to pick some cutoff to select the members. Then use $\\texttt{numpy.where}$ to get the indices of these radial-velocity members.  You may also want to plot a CMD to look at them.*"
+    "*Here, $F_\\mathrm{cluster}\\left(v\\right)$ and $F_\\mathrm{field}\\left(v\\right)$ are the cluster (narrow) and field (broad) components of our two-component Gaussian model. Use this formula below.  Then plot a histogram of the $P\\left(v\\right)$ distribution. Stars with $P\\left(v\\right) \\sim 1$ are high-probability members, while those with $P\\left(v\\right) \\sim 0$ are non-members.  You will want to pick some cutoff to select the members. Then use $\\texttt{numpy.where}$ to get the indices of these radial-velocity members.  You may also want to plot a CMD to look at them.*"
    ]
   },
   {
@@ -275,9 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dist = (r['parallax']).to(u.parsec, equivalencies=u.parallax())\n",
@@ -291,7 +289,7 @@
    "source": [
     "*Now we want to fit the data again, so that we can derive cluster memberships based on distance.  Formally, there is no reason to think the cluster should be a Guassian distribution. (It should be fit with a \"[King model](http://adsabs.harvard.edu/abs/1962AJ.....67..471K)\".)  But let's approximate this by a 1D Gaussian.  Then we can fit the rest of the field with a simple polynomial.*\n",
     "\n",
-    "*Perform this fit to the distance, using $\\texttt{astropy}$.  I suggest using a polynomail of degree 6. Plot the fit on top of the histogram of distances.*"
+    "*Perform this fit to the distance, using $\\texttt{astropy}$.  I suggest using a polynomial of degree 6 for the field. Plot the fit on top of the histogram of distances.*"
    ]
   },
   {
@@ -850,9 +848,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#The Pleiades\n",
@@ -874,9 +870,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#the Hyades\n",
@@ -916,13 +910,6 @@
     "GM.runAll()\n",
     "\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -946,5 +933,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
-Linked GAIA python tutorial no longer exists. Now linking here https://www.cosmos.esa.int/web/gaia-users/archive/use-cases#datalink_dr3_pleiades
-miscellaneous rewording/typos